### PR TITLE
Fixes part of #1: Add some common extensions that were missing

### DIFF
--- a/file_organizers.py
+++ b/file_organizers.py
@@ -17,7 +17,7 @@ extentions = {
     "Adobe": ['.psd', '.bmp', '.psb', '.ct', '.tiff', '.tif', '.eps', '.svg', '.ai', '.webp'],
     "Applications": ['.exe'],
     "Archives": ['.zip', '.rar', '.7zip', '.tar', '.iso', '.tar.gz', 'bz2'],
-    "Code": ['.py', '.java', '.c', '.cpp', '.rb', '.asm', '.php', '.html', '.css', '.js', '.lua', '.jar', '.o', '.obj', '.r'],
+    "Code": ['.py', '.java', '.c', '.cpp', '.rb', '.asm', '.php', '.html', '.css', '.js', '.lua', '.jar', '.o', '.obj', '.r', '.go', '.ts', 'sh'],
     "Documents": ['.docx', '.doc', '.pdf', '.txt', '.ppt', '.pptx', '.ppsx', '.pptm',
                   '.docm', '.dotx', '.dotm', '.docb', '.xlsx', '.xlsm', '.xltx',
                   '.xltm', '.xlsb', '.xla', '.xlam', '.xll', '.xlw',

--- a/file_organizers.py
+++ b/file_organizers.py
@@ -26,7 +26,7 @@ extentions = {
     "Music": ['.mp3', '.ogg', '.wav'],
     "Pictures": ['.jpg', '.jpeg', '.png', '.bmp', '.gif'],
     "Thumbnails": ['.CR2'],
-    "Videos": ['.mp4', '.3gp', '.avi']
+    "Videos": ['.mp4', '.3gp', '.avi', '.mov']
 }
 
 # If you have no '/' in the end

--- a/file_organizers.py
+++ b/file_organizers.py
@@ -22,7 +22,7 @@ extentions = {
                   '.docm', '.dotx', '.dotm', '.docb', '.xlsx', '.xlsm', '.xltx',
                   '.xltm', '.xlsb', '.xla', '.xlam', '.xll', '.xlw',
                   '.ACCDB', '.ACCDE', '.ACCDT', '.ACCDR', '.pub',
-                  '.potx', '.potm', '.ppam', '.ppsm', '.sldx', '.sldm', '.ext'],
+                  '.potx', '.potm', '.ppam', '.ppsm', '.sldx', '.sldm', '.ext', '.epub'],
     "Music": ['.mp3', '.ogg', '.wav'],
     "Pictures": ['.jpg', '.jpeg', '.png', '.bmp', '.gif'],
     "Thumbnails": ['.CR2'],

--- a/file_organizers.py
+++ b/file_organizers.py
@@ -16,7 +16,7 @@ else:
 extentions = {
     "Adobe": ['.psd', '.bmp', '.psb', '.ct', '.tiff', '.tif', '.eps', '.svg', '.ai', '.webp'],
     "Applications": ['.exe'],
-    "Archives": ['.zip', '.rar', '.7zip', '.tar', '.iso', '.tar.gz'],
+    "Archives": ['.zip', '.rar', '.7zip', '.tar', '.iso', '.tar.gz', 'bz2'],
     "Code": ['.py', '.java', '.c', '.cpp', '.rb', '.asm', '.php', '.html', '.css', '.js', '.lua', '.jar', '.o', '.obj', '.r'],
     "Documents": ['.docx', '.doc', '.pdf', '.txt', '.ppt', '.pptx', '.ppsx', '.pptm',
                   '.docm', '.dotx', '.dotm', '.docb', '.xlsx', '.xlsm', '.xltx',


### PR DESCRIPTION
This PR adds a few new extensions in the following categories:
- `archives`
- `code`
- `documents`
- `videos`

Addresses a part of Issue #1 